### PR TITLE
Add -d option to load in additional public domain suffixes

### DIFF
--- a/cmd/giashardid/main.go
+++ b/cmd/giashardid/main.go
@@ -11,10 +11,12 @@ import (
 
 var shards uint
 var slugs bool
+var domainList string
 
 func init() {
 	flag.UintVar(&shards, "n", 8, "Number of shards (2^n)")
 	flag.BoolVar(&slugs, "s", false, "Print slugs instead of shards")
+	flag.StringVar(&domainList, "d", "", "Additional public suffix entries")
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags] [url]\n", os.Args[0])
 		flag.PrintDefaults()
@@ -47,6 +49,14 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
 
+	if domainList != "" {
+		count, err := giashard.AddRulesToDefaultList(domainList)
+		if err != nil {
+			log.Fatalf("Error loading domain list: %v", err)
+		} else {
+			log.Printf("Loaded %d additional public suffix domains.", count)
+		}
+	}
 
 	for url := range urls() {
 		if slugs {

--- a/shard.go
+++ b/shard.go
@@ -85,6 +85,11 @@ func (s *Shard)Close() (err error) {
 	return
 }
 
+func AddRulesToDefaultList(domainList string) (added int, err error) {
+	rules, err := publicsuffix.DefaultList.LoadFile(domainList, nil)
+	return len(rules), err
+}
+
 func Slug(key string) (slug string, err error) {
 	// parse the url to get the domain name
 	url, e := url.Parse(key)


### PR DESCRIPTION
Option to load in additional public suffix domain rules.

In Paracrawl 7 I noticed that some of the English shards were particularly large because they contained all of *.wordpress.com. This option allows us to treat wordpress.com as an additional public suffix, so all those subdomains can go into their own shards.