### PR TITLE
Add support for protocol in fallback regex for shard id

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -10,15 +10,16 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
 	"github.com/weppos/publicsuffix-go/publicsuffix"
 )
 
 type Shard struct {
-	dir string       // root directory
-	n uint           // number of shards (2^n)
-	size int64       // batch size
-	key  string      // key to use for sharding
-	cols []string    // columns
+	dir     string   // root directory
+	n       uint     // number of shards (2^n)
+	size    int64    // batch size
+	key     string   // key to use for sharding
+	cols    []string // columns
 	batches []*Batch
 }
 
@@ -58,8 +59,9 @@ func (se *ShardErr) Unwrap() (err error) {
 
 var host_re *regexp.Regexp
 var path_re *regexp.Regexp
+
 func init() {
-	host_re = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9\-.]*[a-zA-Z0-9]).*`)
+	host_re = regexp.MustCompile(`^(?:[a-zA-Z]+://)?([a-zA-Z0-9][a-zA-Z0-9\-.]*[a-zA-Z0-9]).*`)
 	path_re = regexp.MustCompile(`^([^/]+).*`)
 	ShardError = NewShardErr("Unspecified error", nil)
 }
@@ -68,12 +70,12 @@ func init() {
 // this uses the idea of "domain" from publicsuffix, which tries to get the
 // most "significant" part of a domain name, stripping prefixes and suffixes
 func NewShard(dir string, n uint, size int64, key string, cols ...string) (s *Shard, err error) {
-	batches := make([]*Batch, 1 << n)
+	batches := make([]*Batch, 1<<n)
 	s = &Shard{dir, n, size, key, cols, batches}
 	return
 }
 
-func (s *Shard)Close() (err error) {
+func (s *Shard) Close() (err error) {
 	for _, b := range s.batches {
 		if b != nil {
 			e := b.Close()
@@ -145,8 +147,8 @@ func ShardId(key string, n uint) (shard uint64, err error) {
 // not be fatal: no writing will have happened and it is safe to just
 // skip to the next row. If a different kind of error is returned, it
 // relates to writing the output and should be considered fatal.
-func (s *Shard)WriteRow(row map[string][]byte) (err error) {
-	key  := row[s.key]
+func (s *Shard) WriteRow(row map[string][]byte) (err error) {
+	key := row[s.key]
 
 	shard, err := ShardId(string(key), s.n)
 	if err != nil {
@@ -166,7 +168,7 @@ func (s *Shard)WriteRow(row map[string][]byte) (err error) {
 	return
 }
 
-func (s *Shard)openShard(shard uint64) (b *Batch, err error) {
+func (s *Shard) openShard(shard uint64) (b *Batch, err error) {
 	sdir := s.shardDir(shard)
 	log.Printf("Initialising shard %d at %s", shard, sdir)
 	if err = os.MkdirAll(sdir, os.ModePerm); err != nil {
@@ -177,6 +179,6 @@ func (s *Shard)openShard(shard uint64) (b *Batch, err error) {
 	return
 }
 
-func (s *Shard)shardDir(n uint64) string {
+func (s *Shard) shardDir(n uint64) string {
 	return filepath.Join(s.dir, strconv.FormatInt(int64(n), 10))
 }

--- a/shard_test.go
+++ b/shard_test.go
@@ -5,8 +5,14 @@ import (
 	"testing"
 )
 
-type testcase struct{ url string; n uint; slug string; shard uint64 }
-var testcases [9]testcase = [...]testcase{
+type testcase struct {
+	url   string
+	n     uint
+	slug  string
+	shard uint64
+}
+
+var testcases [11]testcase = [...]testcase{
 	// https://github.com/paracrawl/giashard/issues/1
 	{"http://www.reddit.com/", 8, "reddit", 249},
 	{"http://www.reddit.com/.", 8, "reddit", 249},
@@ -17,6 +23,9 @@ var testcases [9]testcase = [...]testcase{
 	{"tulas-handy-charts.de/en/index.html", 8, "tulas-handy-charts", 179},
 	{"localhost/ford_a/ford_a_restore_2013_02.html", 8, "localhost", 24},
 	{"localhost", 8, "localhost", 24},
+	// https://github.com/paracrawl/giashard/issues/8
+	{"https://www.futuremovieshop.fi/index.php?language=en", 8, "futuremovieshop", 128},
+	{"https://www.futuremovieshop.fi/%s", 8, "futuremovieshop", 128},
 }
 
 func TestSlug(t *testing.T) {


### PR DESCRIPTION
Fix for #3.

This is a breaking change, documents with bad urls that were going into shard 4 might now go to their proper shard. But in the grand scheme of things it shouldn't have any negative impact. Shards will be better balanced.