### PR TITLE
Extract the unique document id from json and output it with the url and text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ go build
 `giashard` uses the following flags:
 - `-o`: Output directory location (default: current directory)
 - `-l`: Input file containing a list of files/directories to shard (default: "")
-- `-f`: Comma-separated list of files to shard for bitextor/Paracrawl column storage format input (default:`"url,mime,plaintext"`)
+- `-f`: Comma-separated list of files to shard for bitextor/Paracrawl column storage format input (default:`"url,mime,plaintext"`). For `jsonl` input this is fixed to `"docid,text,url`".
 - `-n`: Exponent to calculate number of shards (2^n) (default: 8)
 - `-b`: Batch size in MB (default: 100)
 - `-d`: Additional public suffix entries (default: "")

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ go build
 ## Running `giashard`
 `giashard` can accept three input formats:
 1) A directory (or list of directories) in bitextor/Paracrawl column storage format: each directory contains three files named `url.gz`, `mime.gz` and `plain_text.gz` (by default). A different number of files and different names for these files can be specified with the `-f` flag
-2) A zstd-compressed file (or list of files) in the JSONL format where each record contains at minimum one field named `u` containing a URL and one field named `text` containing the extracted content in plain text.
+2) A zstd-compressed file (or list of files) in the JSONL format where each record contains at minimum `u` (the url), `text` (the text) and `id` (a unique id).
 3) An uncompressed stream to stdin in the above JSONL format (indicated by `-` as the input file: e.g. `cat myfile.jsonl | giashard -o myoutput -`)
 
 `giashard` uses the following flags:
 - `-o`: Output directory location (default: current directory)
 - `-l`: Input file containing a list of files/directories to shard (default: "")
-- `-f`: Comma-separated list of files to shard for bitextor/Paracrawl column storage format input (default:`"url,mime,plaintext"`). For `jsonl` input this is fixed to `"docid,text,url`".
+- `-f`: Comma-separated list of files to shard for bitextor/Paracrawl column storage format input (default:`"url,mime,plaintext"`). For `jsonl` input this is fixed to `"id,text,url`".
 - `-n`: Exponent to calculate number of shards (2^n) (default: 8)
 - `-b`: Batch size in MB (default: 100)
 - `-d`: Additional public suffix entries (default: "")

--- a/cmd/giashard/main.go
+++ b/cmd/giashard/main.go
@@ -109,7 +109,7 @@ func main() {
 	flag.Parse()
 	schema = strings.Split(fileslist, ",")
 	if isjsonl {
-		schema = []string{"url", "text"} // need a fixed schema for jsonl
+		schema = []string{"url", "text", "docid"} // need a fixed schema for jsonl
 	}
 
 	// these are extra top-level domains to pick up e.g. '.com', '.co.uk'

--- a/cmd/giashard/main.go
+++ b/cmd/giashard/main.go
@@ -38,8 +38,7 @@ func init() {
 		flag.PrintDefaults()
 		_, err = fmt.Fprintf(flag.CommandLine.Output(),
 			`Shards together the files given on input. They are assumed to be either in the standard 
-			Paracrawl column storage format, or in JSONL format with the data to shard given the names 
-			"url" and "text" in each record. 
+			Paracrawl column storage format, or in the JSONL format used by HPLT monolingual releases.
 			The output is a tree of directories of the form: outdir/shard/batch where shard is 
 			computed as a hash of the significant part of the hostname in a url and batch is 
 			approximately fixed size.

--- a/cmd/giashard/main.go
+++ b/cmd/giashard/main.go
@@ -108,7 +108,7 @@ func main() {
 	flag.Parse()
 	schema = strings.Split(fileslist, ",")
 	if isjsonl {
-		schema = []string{"url", "text", "docid"} // need a fixed schema for jsonl
+		schema = []string{"url", "text", "id"} // need a fixed schema for jsonl
 	}
 
 	// these are extra top-level domains to pick up e.g. '.com', '.co.uk'

--- a/jsonlreader.go
+++ b/jsonlreader.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"os"
-  "strconv"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -15,8 +14,7 @@ import (
 type JsonlRecord struct {
 	Url  string `json:"u"`
 	Text string `json:"text"`
-	File string `json:"f"`
-  Offset int `json:"o"`
+	Id string `json:"id"`
 }
 
 // support reading a zstandard-zipped JSONL file and sending lines to channel (from giashard/LineReader)
@@ -114,7 +112,7 @@ func (r *JsonlReader) Rows() (ch chan map[string][]byte) {
 
 			m["url"] = []byte(v.Url)
 			m["text"] = enc
-			m["docid"] = []byte(v.File + ":" + strconv.Itoa(v.Offset))
+			m["id"] = []byte(v.Id)
 			ch <- m
 		}
 	}()

--- a/jsonlreader.go
+++ b/jsonlreader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+  "strconv"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -14,6 +15,8 @@ import (
 type JsonlRecord struct {
 	Url  string `json:"u"`
 	Text string `json:"text"`
+	File string `json:"f"`
+  Offset int `json:"o"`
 }
 
 // support reading a zstandard-zipped JSONL file and sending lines to channel (from giashard/LineReader)
@@ -111,6 +114,7 @@ func (r *JsonlReader) Rows() (ch chan map[string][]byte) {
 
 			m["url"] = []byte(v.Url)
 			m["text"] = enc
+			m["docid"] = []byte(v.File + ":" + strconv.Itoa(v.Offset))
 			ch <- m
 		}
 	}()


### PR DESCRIPTION
This PR adds extra functionality to the json sharder, so that it copies the id field from json to the output.